### PR TITLE
Make the extension compatible with TYPO3 8.7

### DIFF
--- a/Classes/ClientProvider.php
+++ b/Classes/ClientProvider.php
@@ -14,10 +14,10 @@ class ClientProvider
     /**
      * Log an exception to sentry
      *
-     * @param \Exception $exception The Exception object.
+     * @param \Throwable $exception The Exception object.
      * @param array      $data      Additional attributes to pass with this event (see Sentry docs).
      */
-    public static function captureException($exception, $data = null)
+    public static function captureException(\Throwable $exception, $data = null)
     {
         if (null === $data) {
             $data = [

--- a/Classes/ClientProvider.php
+++ b/Classes/ClientProvider.php
@@ -21,10 +21,10 @@ class ClientProvider
     {
         if (null === $data) {
             $data = [
-                'extra' => array(
+                'extra' => [
                     'backend_user' => self::getBackendUserAddress(),
                     'client_ip'    => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '',
-                ),
+                ],
             ];
         }
 
@@ -146,12 +146,12 @@ class ClientProvider
      */
     private static function getTagsContext()
     {
-        return array(
+        return [
             'typo3_version'       => TYPO3_version,
             'typo3_mode'          => TYPO3_MODE,
             'php_version'         => phpversion(),
             'application_context' => (string)GeneralUtility::getApplicationContext(),
-        );
+        ];
     }
 
     /**
@@ -183,10 +183,10 @@ class ClientProvider
      */
     private static function getClientOptions()
     {
-        $clientOptions = array(
+        $clientOptions = [
             'error_types'                         => static::getErrorMask(),
             'install_default_breadcrumb_handlers' => false,
-        );
+        ];
         if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer'])) {
             $clientOptions['http_proxy'] = $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer'];
         }

--- a/Classes/DebugExceptionHandler.php
+++ b/Classes/DebugExceptionHandler.php
@@ -14,12 +14,11 @@ class DebugExceptionHandler extends \TYPO3\CMS\Core\Error\DebugExceptionHandler
     /**
      * Displays the given exception
      *
-     * @param \Exception|\Throwable $exception The exception(PHP 5.x) or throwable(PHP >= 7.0) object.
-     * @TODO #72293 This will change to \Throwable only if we are >= PHP7.0 only
+     * @param \Throwable $exception The exception(PHP 5.x) or throwable(PHP >= 7.0) object.
      *
      * @throws \Exception
      */
-    public function handleException($exception)
+    public function handleException(\Throwable $exception)
     {
         ClientProvider::captureException($exception);
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "TYPO3 Extension for exception logging with sentry, see http://www.getsentry.com",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": ">=6.2.0,<8.9.99"
+        "typo3/cms-core": ">=6.2.0,<8.9.99",
+        "sentry/sentry": "~1.7.1"
     },
     "license": [
         "GPL-2.0+"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "TYPO3 Extension for exception logging with sentry, see http://www.getsentry.com",
     "type": "typo3-cms-extension",
     "require": {
-        "typo3/cms-core": ">=6.2.0,<8.9.99",
+        "php": "^7.0",
+        "typo3/cms-core": ">=8.7.0,<8.7.99",
         "sentry/sentry": "~1.7.1"
     },
     "license": [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF[$_EXTKEY] = array (
+$EM_CONF[$_EXTKEY] = [
 	'title' => 'Sentry Client',
 	'description' => 'Sentry Client for TYPO3 - https://www.getsentry.com/',
 	'category' => 'services',
@@ -12,17 +12,11 @@ $EM_CONF[$_EXTKEY] = array (
 	'author' => 'Christoph Lehmann',
 	'author_email' => 'christoph.lehmann@networkteam.com',
 	'author_company' => 'networkteam GmbH',
-	'constraints' => 
-	array (
-		'depends' => 
-		array (
+	'constraints' => [
+		'depends' => [
 			'typo3' => '6.2.0-7.9.99',
-		),
-		'conflicts' => 
-		array (
-		),
-		'suggests' => 
-		array (
-		),
-	),
-);
+		],
+		'conflicts' => [],
+		'suggests' => [],
+	],
+];


### PR DESCRIPTION
The current version of the extension fails with a type mismatch error when setting the DSN for Sentry because TYPO3 8.7 type hints to `\Throwable` in `\TYPO3\CMS\Core\Error\DebugExceptionHandler::handleException()`. 